### PR TITLE
Update build.xml to support moving help pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,30 @@
 # Constellation Applications
 
-[Constellation](https://github.com/constellation-app/constellation) is a 
-graph-focused data visualisation and interactive analysis application enabling 
-data access, federation and manipulation capabilities across large and complex 
+[Constellation](https://github.com/constellation-app/constellation) is a
+graph-focused data visualisation and interactive analysis application enabling
+data access, federation and manipulation capabilities across large and complex
 data sets.
 
 The intention of this repository is to use scripts to build different versions
 of Constellation and keep the jre build logic isolated to this repository.
 
-This repository also hosts the build scripts used to build the versions of 
+This repository also hosts the build scripts used to build the versions of
 Constellation available on [the official website](https://constellation-app.com).
 
 # List of Applications
 
 ## Constellation
 
-The version of Constellation available from 
-[the official website](https://constellation-app.com) and includes the following 
+The version of Constellation available from
+[the official website](https://constellation-app.com) and includes the following
 module suites:
   * [Constellation](https://github.com/constellation-app/constellation)
   * [Constellation Adaptors](https://github.com/constellation-app/constellation-adaptors)
 
 ## Constellation Cyber
 
-A special distribution of Constellation for Cyber analysts and is also available 
-from the [the official website](https://constellation-app.com) and includes the 
+A special distribution of Constellation for Cyber analysts and is also available
+from the [the official website](https://constellation-app.com) and includes the
 following module suites:
   * [Constellation](https://github.com/constellation-app/constellation)
   * [Constellation Adaptors](https://github.com/constellation-app/constellation-adaptors)
@@ -34,7 +34,7 @@ following module suites:
 
 ## Build Constellation
 
-Prior to building Constellation, `CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/startup/Startup.java` 
+Prior to building Constellation, `CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/startup/Startup.java`
 should be updated to specify the version number like the following:
 
 ```java
@@ -55,16 +55,18 @@ sudo docker run -v "$PWD:/code" -v "$HOME/.ivy2:/root/.ivy2" --workdir \
 
 This will build distributions of Constellation for Windows, Linux and MacOSX and will be available from `constellation-applications/constellation/dist`
 
+NOTE: To include updated help documentation, running the applications constellation-adaptors will generate an updated toc.md file.
+
 ## Build Constellation Cyber
 
-Prior to building Constellation, `CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/startup/Startup.java` 
+Prior to building Constellation, `CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/startup/Startup.java`
 should be updated to specify the version number like the following:
 
 ```java
 private static final String VERSION = "v1.0.0";
 ```
 
-Also the application branding should be updated by updating `CoreUtilities/src/au/gov/asd/tac/constellation/utilities/BrandingUtilities.java` 
+Also the application branding should be updated by updating `CoreUtilities/src/au/gov/asd/tac/constellation/utilities/BrandingUtilities.java`
 with the title of the application being:
 
 ```java
@@ -87,7 +89,9 @@ sudo docker run -v "$PWD:/code" -v "$HOME/.ivy2:/root/.ivy2" --workdir \
 
 This will build distributions of Constellation for Windows, Linux and MacOSX and will be available from `constellation-applications/constellation-cyber/dist`
 
+NOTE: To include updated help documentation, running the applications constellation-adaptors and constellation_cyber_plugins will generate an updated toc.md file.
+
 ## More Information
 
-This repository should follow everything mentioned in the Constellation 
+This repository should follow everything mentioned in the Constellation
 [README](https://github.com/constellation-app/constellation/blob/master/README.md).

--- a/constellation-cyber/build.xml
+++ b/constellation-cyber/build.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project name="Constellation Cyber" basedir="." xmlns:ivy="antlib:org.apache.ivy.ant" xmlns:if="ant:if" xmlns:unless="ant:unless">
     <description>Builds the Constellation Cyber module suite which is hosted on https://constellation-app.com</description>
-    
+
     <import file="nbproject/build-impl.xml"/>
-    
+
     <!-- build jre zips -->
     <property name="dist.version" value="v1.2.0"/>
     <property name="jre.filename.windows" value="zulu11.37.19-ca-fx-jre11.0.6-win_x64"/>
@@ -16,7 +16,17 @@
     <property name="dist.filename.windows" value="constellation-cyber-win-${dist.version}"/>
     <property name="dist.filename.macosx" value="constellation-cyber-macosx-${dist.version}"/>
     <property name="nobody" value="65534"/>
-    
+
+    <property name="help.deploy.dir" value="dist/constellation_cyber_plugins"/>
+    <property name="help.docs.dir" value="**/docs"/>
+    <property name="help.docs.resources.dir" value="**/docs/resources"/>
+    <property name="help.type.md" value="**.md"/>
+    <property name="help.type.png" value="**.png"/>
+    <property name="help.type.jpg" value="**.jpg"/>
+    <property name="help.bootstrap.dir" value="bootstrap/**"/>
+    <property name="help.toc.file" value="toc.md"/>
+
+
     <!-- Windows Section -->
 
     <target name="-download-windows-jre" >
@@ -27,7 +37,7 @@
         <delete file="${basedir}/${jre.filename.windows}.zip"/>
     </target>
 
-    <target name="build-zip-with-windows-jre" depends="build,build-launchers,-download-windows-jre" 
+    <target name="build-zip-with-windows-jre" depends="build,build-launchers,-download-windows-jre"
             description="Builds a ZIP distribution of the suite, launchers, and selected modules from the platform. This includes the JRE for Windows.">
         <mkdir dir="${dist.dir}"/>
         <!-- pathfileset does not support 'prefix' and 'filemode' parameters, we have to copy them to temp location -->
@@ -43,13 +53,53 @@
                  destdir="${build.launcher.dir}/etc/"
                  preservelastmodified="true"
                  eol="crlf" />
-        
-        <!-- work around to get the modified help jars to the build -->
-        <copy file="${nbplatform.default.netbeans.dest.dir}/platform/modules/ext/jhall-2.0_05.jar" todir="${temp.dir.rest}/platform/modules/ext" verbose="true"/>
-        
+
+         <copy todir="${dist.dir}/${app.name}" overwrite="true" includeEmptyDirs="false">
+             <fileset dir="${basedir}\..\..\constellation">
+                 <include name="${help.toc.file}"/>
+                 <include name="${help.bootstrap.dir}"/>
+                 <include name="${help.docs.dir}/${help.type.md}"/>
+                 <include name="${help.docs.dir}/${help.type.png}"/>
+                 <include name="${help.docs.dir}/${help.type.jpg}"/>
+                 <include name="${help.docs.resources.dir}/${help.type.md}"/>
+                 <include name="${help.docs.resources.dir}/${help.type.png}"/>
+                 <include name="${help.docs.resources.dir}/${help.type.jpg}"/>
+                 <exclude name="docs/**"/>
+                 <exclude name="**/build/**"/>
+                 <exclude name="${help.deploy.dir}/**"/>
+             </fileset>
+         </copy>
+         <copy todir="${dist.dir}/${app.name}-adaptors" overwrite="true" includeEmptyDirs="false">
+             <fileset dir="${basedir}\..\..\constellation-adaptors">
+                 <include name="${help.toc.file}"/>
+                 <include name="${help.bootstrap.dir}"/>
+                 <include name="${help.docs.dir}/${help.type.md}"/>
+                 <include name="${help.docs.dir}/${help.type.png}"/>
+                 <include name="${help.docs.dir}/${help.type.jpg}"/>
+                 <include name="${help.docs.resources.dir}/${help.type.md}"/>
+                 <include name="${help.docs.resources.dir}/${help.type.png}"/>
+                 <include name="${help.docs.resources.dir}/${help.type.jpg}"/>
+                 <exclude name="docs/**"/>
+                 <exclude name="**/build/**"/>
+                 <exclude name="${help.deploy.dir}/**"/>
+             </fileset>
+         </copy>
+         <copy todir="${help.deploy.dir}" verbose="true" overwrite="true" includeEmptyDirs="false">
+             <fileset dir="${basedir}\..\..\constellation_cyber_plugins">
+                 <include name="${help.docs.dir}/${help.type.md}"/>
+                 <include name="${help.docs.dir}/${help.type.png}"/>
+                 <include name="${help.docs.dir}/${help.type.jpg}"/>
+                 <include name="${help.docs.resources.dir}/${help.type.md}"/>
+                 <include name="${help.docs.resources.dir}/${help.type.png}"/>
+                 <include name="${help.docs.resources.dir}/${help.type.jpg}"/>
+                 <exclude name="**/build/**"/>
+                 <exclude name="dist/**"/>
+             </fileset>
+         </copy>
+
         <!-- delete the harness folder which is only required for testing -->
         <delete dir="${temp.dir.rest}/harness"/>
-                
+
         <zip destfile="${dist.dir}/${dist.filename.windows}.zip">
             <!-- Using pre-built executable files that come with the Constellation icon -->
             <!--<zipfileset dir="${build.launcher.dir}/bin/" filemode="755" prefix="${app.name}/bin"/>-->
@@ -58,14 +108,22 @@
             <zipfileset dir="${temp.dir.nbexec}" filemode="755" prefix="${app.name}"/>
             <zipfileset dir="${temp.dir.rest}" prefix="${app.name}"/>
             <zipfileset dir="${basedir}/${jre.filename.windows}/" prefix="${app.name}/jre"/>
+            <zipfileset dir="${help.deploy.dir}" prefix="constellation/constellation_cyber_plugins"/>
+            <zipfileset dir="${dist.dir}/${app.name}" prefix="constellation/constellation"/>
+            <zipfileset dir="${dist.dir}/${app.name}-adaptors" prefix="constellation/constellation-adaptors"/>
             <!-- Yes, the doubled app.name is a bit ugly, but better than the alternative; cf. #66441: -->
             <zipfileset dir="${cluster}" prefix="${app.name}/${app.name}">
                 <exclude name="config/Modules/*.xml_hidden"/>
             </zipfileset>
         </zip>
         <delete dir="${basedir}/${jre.filename.windows}/"/>
+        <delete dir="${help.deploy.dir}/constellation_cyber_plugins"/>
+        <delete dir="dist/constellation_cyber_plugins"/>
+        <delete dir="${help.deploy.dir}"/>
+        <delete dir="${dist.dir}/${app.name}"/>
+        <delete dir="${dist.dir}/${app.name}-adaptors"/>
     </target>
-    
+
     <!-- MacOSX Section -->
 
     <!-- This is a copy of -download-windows-jre, if there is a better way to do this then let me know -->
@@ -78,7 +136,7 @@
     </target>
 
     <!-- This is a copy of build-zip-with-windows-jre", if there is a better way to do this then let me know -->
-    <target name="build-zip-with-macosx-jre" depends="build,build-launchers,-download-macosx-jre" 
+    <target name="build-zip-with-macosx-jre" depends="build,build-launchers,-download-macosx-jre"
             description="Builds a ZIP distribution of the suite, launchers, and selected modules from the platform. This includes the JRE for MacOSX.">
         <mkdir dir="${dist.dir}"/>
         <!-- pathfileset does not support 'prefix' and 'filemode' parameters, we have to copy them to temp location -->
@@ -94,13 +152,54 @@
                  destdir="${build.launcher.dir}/etc/"
                  preservelastmodified="true"
                  eol="lf" />
-        
-        <!-- work around to get the modified help jars to the build -->
-        <copy file="${nbplatform.default.netbeans.dest.dir}/platform/modules/ext/jhall-2.0_05.jar" todir="${temp.dir.rest}/platform/modules/ext" verbose="true"/>
-        
+
+
+         <copy todir="${dist.dir}/${app.name}" overwrite="true" includeEmptyDirs="false">
+             <fileset dir="${basedir}\..\..\constellation">
+                 <include name="${help.toc.file}"/>
+                 <include name="${help.bootstrap.dir}"/>
+                 <include name="${help.docs.dir}/${help.type.md}"/>
+                 <include name="${help.docs.dir}/${help.type.png}"/>
+                 <include name="${help.docs.dir}/${help.type.jpg}"/>
+                 <include name="${help.docs.resources.dir}/${help.type.md}"/>
+                 <include name="${help.docs.resources.dir}/${help.type.png}"/>
+                 <include name="${help.docs.resources.dir}/${help.type.jpg}"/>
+                 <exclude name="docs/**"/>
+                 <exclude name="**/build/**"/>
+                 <exclude name="${help.deploy.dir}/**"/>
+             </fileset>
+         </copy>
+         <copy todir="${dist.dir}/${app.name}-adaptors" overwrite="true" includeEmptyDirs="false">
+             <fileset dir="${basedir}\..\..\constellation-adaptors">
+                 <include name="${help.toc.file}"/>
+                 <include name="${help.bootstrap.dir}"/>
+                 <include name="${help.docs.dir}/${help.type.md}"/>
+                 <include name="${help.docs.dir}/${help.type.png}"/>
+                 <include name="${help.docs.dir}/${help.type.jpg}"/>
+                 <include name="${help.docs.resources.dir}/${help.type.md}"/>
+                 <include name="${help.docs.resources.dir}/${help.type.png}"/>
+                 <include name="${help.docs.resources.dir}/${help.type.jpg}"/>
+                 <exclude name="docs/**"/>
+                 <exclude name="**/build/**"/>
+                 <exclude name="${help.deploy.dir}/**"/>
+             </fileset>
+         </copy>
+         <copy todir="${help.deploy.dir}" verbose="true" overwrite="true" includeEmptyDirs="false">
+             <fileset dir="${basedir}\..\..\constellation_cyber_plugins">
+                 <include name="${help.docs.dir}/${help.type.md}"/>
+                 <include name="${help.docs.dir}/${help.type.png}"/>
+                 <include name="${help.docs.dir}/${help.type.jpg}"/>
+                 <include name="${help.docs.resources.dir}/${help.type.md}"/>
+                 <include name="${help.docs.resources.dir}/${help.type.png}"/>
+                 <include name="${help.docs.resources.dir}/${help.type.jpg}"/>
+                 <exclude name="**/build/**"/>
+                 <exclude name="dist/**"/>
+             </fileset>
+         </copy>
+
         <!-- delete the harness folder which is only required for testing -->
         <delete dir="${temp.dir.rest}/harness"/>
-        
+
         <tar destfile="${dist.dir}/${dist.filename.macosx}.tar">
             <!-- Using pre-built executable files that come with the Constellation icon -->
             <!--<tarfileset dir="${build.launcher.dir}/bin/" filemode="755" prefix="${app.name}/bin"/>-->
@@ -117,7 +216,9 @@
                 <exclude name="bin/*"/>
             </tarfileset>
             <tarfileset dir="${basedir}/${jre.filename.macosx}/bin/" filemode="755" prefix="${app.name}/jre/bin" uid="${nobody}" gid="${nobody}"/>
-
+            <tarfileset dir="${help.deploy.dir}" prefix="constellation/constellation_cyber_plugins" uid="${nobody}" gid="${nobody}"/>
+            <tarfileset dir="${dist.dir}/${app.name}" prefix="constellation/constellation" uid="${nobody}" gid="${nobody}"/>
+            <tarfileset dir="${dist.dir}/${app.name}-adaptors" prefix="constellation/constellation-adaptors" uid="${nobody}" gid="${nobody}"/>
             <!-- Yes, the doubled app.name is a bit ugly, but better than the alternative; cf. #66441: -->
             <tarfileset dir="${cluster}" prefix="${app.name}/${app.name}" uid="${nobody}" gid="${nobody}">
                 <exclude name="config/Modules/*.xml_hidden"/>
@@ -126,8 +227,13 @@
         <gzip src="${dist.dir}/${dist.filename.macosx}.tar" destfile="${dist.dir}/${dist.filename.macosx}.tar.gz"/>
         <delete file="${dist.dir}/${dist.filename.macosx}.tar"/>
         <delete dir="${basedir}/${jre.filename.macosx}/"/>
+        <delete dir="${help.deploy.dir}/constellation_cyber_plugins"/>
+        <delete dir="dist/constellation_cyber_plugins"/>
+        <delete dir="${help.deploy.dir}"/>
+        <delete dir="${dist.dir}/${app.name}"/>
+        <delete dir="${dist.dir}/${app.name}-adaptors"/>
     </target>
-    
+
     <!-- Linux Section -->
 
     <!-- This is a copy of -download-windows-jre, if there is a better way to do this then let me know -->
@@ -140,7 +246,7 @@
     </target>
 
     <!-- This is a copy of build-zip-with-windows-jre", if there is a better way to do this then let me know -->
-    <target name="build-zip-with-linux-jre" depends="build,build-launchers,-download-linux-jre" 
+    <target name="build-zip-with-linux-jre" depends="build,build-launchers,-download-linux-jre"
             description="Builds a ZIP distribution of the suite, launchers, and selected modules from the platform. This includes the JRE for Linux.">
         <mkdir dir="${dist.dir}"/>
         <!-- pathfileset does not support 'prefix' and 'filemode' parameters, we have to copy them to temp location -->
@@ -156,13 +262,54 @@
                  destdir="${build.launcher.dir}/etc/"
                  preservelastmodified="true"
                  eol="lf" />
-        
-        <!-- work around to get the modified help jars to the build -->
-        <copy file="${nbplatform.default.netbeans.dest.dir}/platform/modules/ext/jhall-2.0_05.jar" todir="${temp.dir.rest}/platform/modules/ext" verbose="true"/>
-        
+
+
+         <copy todir="${dist.dir}/${app.name}" overwrite="true" includeEmptyDirs="false">
+             <fileset dir="${basedir}\..\..\constellation">
+                 <include name="${help.toc.file}"/>
+                 <include name="${help.bootstrap.dir}"/>
+                 <include name="${help.docs.dir}/${help.type.md}"/>
+                 <include name="${help.docs.dir}/${help.type.png}"/>
+                 <include name="${help.docs.dir}/${help.type.jpg}"/>
+                 <include name="${help.docs.resources.dir}/${help.type.md}"/>
+                 <include name="${help.docs.resources.dir}/${help.type.png}"/>
+                 <include name="${help.docs.resources.dir}/${help.type.jpg}"/>
+                 <exclude name="docs/**"/>
+                 <exclude name="**/build/**"/>
+                 <exclude name="${help.deploy.dir}/**"/>
+             </fileset>
+         </copy>
+         <copy todir="${dist.dir}/${app.name}-adaptors" overwrite="true" includeEmptyDirs="false">
+             <fileset dir="${basedir}\..\..\constellation-adaptors">
+                 <include name="${help.toc.file}"/>
+                 <include name="${help.bootstrap.dir}"/>
+                 <include name="${help.docs.dir}/${help.type.md}"/>
+                 <include name="${help.docs.dir}/${help.type.png}"/>
+                 <include name="${help.docs.dir}/${help.type.jpg}"/>
+                 <include name="${help.docs.resources.dir}/${help.type.md}"/>
+                 <include name="${help.docs.resources.dir}/${help.type.png}"/>
+                 <include name="${help.docs.resources.dir}/${help.type.jpg}"/>
+                 <exclude name="docs/**"/>
+                 <exclude name="**/build/**"/>
+                 <exclude name="${help.deploy.dir}/**"/>
+             </fileset>
+         </copy>
+         <copy todir="${help.deploy.dir}" verbose="true" overwrite="true" includeEmptyDirs="false">
+             <fileset dir="${basedir}\..\..\constellation_cyber_plugins">
+                 <include name="${help.docs.dir}/${help.type.md}"/>
+                 <include name="${help.docs.dir}/${help.type.png}"/>
+                 <include name="${help.docs.dir}/${help.type.jpg}"/>
+                 <include name="${help.docs.resources.dir}/${help.type.md}"/>
+                 <include name="${help.docs.resources.dir}/${help.type.png}"/>
+                 <include name="${help.docs.resources.dir}/${help.type.jpg}"/>
+                 <exclude name="**/build/**"/>
+                 <exclude name="dist/**"/>
+             </fileset>
+         </copy>
+
         <!-- delete the harness folder which is only required for testing -->
         <delete dir="${temp.dir.rest}/harness"/>
-        
+
         <tar destfile="${dist.dir}/${dist.filename.linux}.tar">
             <!-- Using pre-built executable files that come with the Constellation icon -->
             <!--<tarfileset dir="${build.launcher.dir}/bin/" filemode="755" prefix="${app.name}/bin"/>-->
@@ -179,7 +326,9 @@
                 <exclude name="bin/*"/>
             </tarfileset>
             <tarfileset dir="${basedir}/${jre.filename.linux}/bin/" filemode="755" prefix="${app.name}/jre/bin" uid="${nobody}" gid="${nobody}"/>
-
+            <tarfileset dir="${help.deploy.dir}" prefix="constellation/constellation_cyber_plugins" uid="${nobody}" gid="${nobody}"/>
+            <tarfileset dir="${dist.dir}/${app.name}" prefix="constellation/constellation" uid="${nobody}" gid="${nobody}"/>
+            <tarfileset dir="${dist.dir}/${app.name}-adaptors" prefix="constellation/constellation-adaptors" uid="${nobody}" gid="${nobody}"/>
             <!-- Yes, the doubled app.name is a bit ugly, but better than the alternative; cf. #66441: -->
             <tarfileset dir="${cluster}" prefix="${app.name}/${app.name}" uid="${nobody}" gid="${nobody}">
                 <exclude name="config/Modules/*.xml_hidden"/>
@@ -188,6 +337,11 @@
         <gzip src="${dist.dir}/${dist.filename.linux}.tar" destfile="${dist.dir}/${dist.filename.linux}.tar.gz"/>
         <delete file="${dist.dir}/${dist.filename.linux}.tar"/>
         <delete dir="${basedir}/${jre.filename.linux}/"/>
+        <delete dir="${help.deploy.dir}/constellation_cyber_plugins"/>
+        <delete dir="dist/constellation_cyber_plugins"/>
+        <delete dir="${help.deploy.dir}"/>
+        <delete dir="${dist.dir}/${app.name}"/>
+        <delete dir="${dist.dir}/${app.name}-adaptors"/>
     </target>
 
 </project>

--- a/constellation/build.xml
+++ b/constellation/build.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project name="Constellation Application" basedir="." xmlns:ivy="antlib:org.apache.ivy.ant" xmlns:if="ant:if" xmlns:unless="ant:unless">
     <description>Builds the Constellation module suite which is hosted on https://constellation-app.com</description>
-    
+
     <import file="nbproject/build-impl.xml"/>
-    
+
     <!-- build jre zips -->
     <property name="dist.version" value="v2.3.0"/>
     <property name="jre.filename.windows" value="zulu11.37.19-ca-fx-jre11.0.6-win_x64"/>
@@ -16,7 +16,16 @@
     <property name="dist.filename.windows" value="constellation-win-${dist.version}"/>
     <property name="dist.filename.macosx" value="constellation-macosx-${dist.version}"/>
     <property name="nobody" value="65534"/>
-    
+
+    <property name="help.deploy.dir" value="dist/constellation/constellation"/>
+    <property name="help.docs.dir" value="**/docs"/>
+    <property name="help.docs.resources.dir" value="**/docs/resources"/>
+    <property name="help.type.md" value="**.md"/>
+    <property name="help.type.png" value="**.png"/>
+    <property name="help.type.jpg" value="**.jpg"/>
+    <property name="help.bootstrap.dir" value="bootstrap/**"/>
+    <property name="help.toc.file" value="toc.md"/>
+
     <!-- Windows Section -->
 
     <target name="-download-windows-jre" >
@@ -27,7 +36,7 @@
         <delete file="${basedir}/${jre.filename.windows}.zip"/>
     </target>
 
-    <target name="build-zip-with-windows-jre" depends="build,build-launchers,-download-windows-jre" 
+    <target name="build-zip-with-windows-jre" depends="build,build-launchers,-download-windows-jre"
             description="Builds a ZIP distribution of the suite, launchers, and selected modules from the platform. This includes the JRE for Windows.">
         <mkdir dir="${dist.dir}"/>
         <!-- pathfileset does not support 'prefix' and 'filemode' parameters, we have to copy them to temp location -->
@@ -43,13 +52,41 @@
                  destdir="${build.launcher.dir}/etc/"
                  preservelastmodified="true"
                  eol="crlf" />
-        
-        <!-- work around to get the modified help jars to the build -->
-        <copy file="${nbplatform.default.netbeans.dest.dir}/platform/modules/ext/jhall-2.0_05.jar" todir="${temp.dir.rest}/platform/modules/ext" verbose="true"/>
-        
+
         <!-- delete the harness folder which is only required for testing -->
         <delete dir="${temp.dir.rest}/harness"/>
-                
+
+        <copy todir="${dist.dir}/${dist.filename.windows}/${app.name}" overwrite="true" includeEmptyDirs="false">
+            <fileset dir="${basedir}\..\..\${app.name}">
+                <include name="${help.toc.file}"/>
+                <include name="${help.bootstrap.dir}"/>
+                <include name="${help.docs.dir}/${help.type.md}"/>
+                <include name="${help.docs.dir}/${help.type.png}"/>
+                <include name="${help.docs.dir}/${help.type.jpg}"/>
+                <include name="${help.docs.resources.dir}/${help.type.md}"/>
+                <include name="${help.docs.resources.dir}/${help.type.png}"/>
+                <include name="${help.docs.resources.dir}/${help.type.jpg}"/>
+                <exclude name="docs/**"/>
+                <exclude name="**/build/**"/>
+                <exclude name="${help.deploy.dir}/**"/>
+            </fileset>
+        </copy>
+        <copy todir="${dist.dir}/${dist.filename.windows}/constellation-adaptors" overwrite="true" includeEmptyDirs="false">
+            <fileset dir="${basedir}\..\..\constellation-adaptors">
+                <include name="${help.toc.file}"/>
+                <include name="${help.bootstrap.dir}"/>
+                <include name="${help.docs.dir}/${help.type.md}"/>
+                <include name="${help.docs.dir}/${help.type.png}"/>
+                <include name="${help.docs.dir}/${help.type.jpg}"/>
+                <include name="${help.docs.resources.dir}/${help.type.md}"/>
+                <include name="${help.docs.resources.dir}/${help.type.png}"/>
+                <include name="${help.docs.resources.dir}/${help.type.jpg}"/>
+                <exclude name="docs/**"/>
+                <exclude name="**/build/**"/>
+                <exclude name="${help.deploy.dir}/**"/>
+            </fileset>
+        </copy>
+
         <zip destfile="${dist.dir}/${dist.filename.windows}.zip">
             <!-- Using pre-built executable files that come with the Constellation icon -->
             <!--<zipfileset dir="${build.launcher.dir}/bin/" filemode="755" prefix="${app.name}/bin"/>-->
@@ -58,14 +95,19 @@
             <zipfileset dir="${temp.dir.nbexec}" filemode="755" prefix="${app.name}"/>
             <zipfileset dir="${temp.dir.rest}" prefix="${app.name}"/>
             <zipfileset dir="${basedir}/${jre.filename.windows}/" prefix="${app.name}/jre"/>
+            <zipfileset dir="${dist.dir}/${dist.filename.windows}/${app.name}" prefix="${app.name}/${app.name}"/>
+            <zipfileset dir="${dist.dir}/${dist.filename.windows}/constellation-adaptors" prefix="${app.name}/${app.name}-adaptors"/>
             <!-- Yes, the doubled app.name is a bit ugly, but better than the alternative; cf. #66441: -->
             <zipfileset dir="${cluster}" prefix="${app.name}/${app.name}">
                 <exclude name="config/Modules/*.xml_hidden"/>
             </zipfileset>
         </zip>
         <delete dir="${basedir}/${jre.filename.windows}/"/>
+        <delete dir="${dist.dir}/${dist.filename.windows}/${app.name}"/>
+        <delete dir="${dist.dir}/${dist.filename.windows}/constellation-adaptors"/>
+        <delete dir="${dist.dir}/${dist.filename.windows}"/>
     </target>
-    
+
     <!-- MacOSX Section -->
 
     <!-- This is a copy of -download-windows-jre, if there is a better way to do this then let me know -->
@@ -78,7 +120,7 @@
     </target>
 
     <!-- This is a copy of build-zip-with-windows-jre", if there is a better way to do this then let me know -->
-    <target name="build-zip-with-macosx-jre" depends="build,build-launchers,-download-macosx-jre" 
+    <target name="build-zip-with-macosx-jre" depends="build,build-launchers,-download-macosx-jre"
             description="Builds a ZIP distribution of the suite, launchers, and selected modules from the platform. This includes the JRE for MacOSX.">
         <mkdir dir="${dist.dir}"/>
         <!-- pathfileset does not support 'prefix' and 'filemode' parameters, we have to copy them to temp location -->
@@ -94,13 +136,26 @@
                  destdir="${build.launcher.dir}/etc/"
                  preservelastmodified="true"
                  eol="lf" />
-        
-        <!-- work around to get the modified help jars to the build -->
-        <copy file="${nbplatform.default.netbeans.dest.dir}/platform/modules/ext/jhall-2.0_05.jar" todir="${temp.dir.rest}/platform/modules/ext" verbose="true"/>
-        
+
         <!-- delete the harness folder which is only required for testing -->
         <delete dir="${temp.dir.rest}/harness"/>
-        
+
+        <copy todir="${dist.dir}/${dist.filename.macosx}/${app.name}" overwrite="true" includeEmptyDirs="false">
+            <fileset dir="${basedir}\..\..\${app.name}">
+                <include name="${help.toc.file}"/>
+                <include name="${help.bootstrap.dir}"/>
+                <include name="${help.docs.dir}/${help.type.md}"/>
+                <include name="${help.docs.dir}/${help.type.png}"/>
+                <include name="${help.docs.dir}/${help.type.jpg}"/>
+                <include name="${help.docs.resources.dir}/${help.type.md}"/>
+                <include name="${help.docs.resources.dir}/${help.type.png}"/>
+                <include name="${help.docs.resources.dir}/${help.type.jpg}"/>
+                <exclude name="docs/**"/>
+                <exclude name="**/build/**"/>
+                <exclude name="${help.deploy.dir}/**"/>
+            </fileset>
+        </copy>
+
         <tar destfile="${dist.dir}/${dist.filename.macosx}.tar">
             <!-- Using pre-built executable files that come with the Constellation icon -->
             <!--<tarfileset dir="${build.launcher.dir}/bin/" filemode="755" prefix="${app.name}/bin"/>-->
@@ -118,6 +173,8 @@
             </tarfileset>
             <tarfileset dir="${basedir}/${jre.filename.macosx}/bin/" filemode="755" prefix="${app.name}/jre/bin" uid="${nobody}" gid="${nobody}"/>
 
+            <tarfileset dir="${dist.dir}/${dist.filename.macosx}/${app.name}" prefix="${app.name}/${app.name}" uid="${nobody}" gid="${nobody}"/>
+
             <!-- Yes, the doubled app.name is a bit ugly, but better than the alternative; cf. #66441: -->
             <tarfileset dir="${cluster}" prefix="${app.name}/${app.name}" uid="${nobody}" gid="${nobody}">
                 <exclude name="config/Modules/*.xml_hidden"/>
@@ -126,8 +183,10 @@
         <gzip src="${dist.dir}/${dist.filename.macosx}.tar" destfile="${dist.dir}/${dist.filename.macosx}.tar.gz"/>
         <delete file="${dist.dir}/${dist.filename.macosx}.tar"/>
         <delete dir="${basedir}/${jre.filename.macosx}/"/>
+        <delete dir="${dist.dir}/${dist.filename.macosx}/${app.name}"/>
+        <delete dir="${dist.dir}/${dist.filename.macosx}"/>
     </target>
-    
+
     <!-- Linux Section -->
 
     <!-- This is a copy of -download-windows-jre, if there is a better way to do this then let me know -->
@@ -140,7 +199,7 @@
     </target>
 
     <!-- This is a copy of build-zip-with-windows-jre", if there is a better way to do this then let me know -->
-    <target name="build-zip-with-linux-jre" depends="build,build-launchers,-download-linux-jre" 
+    <target name="build-zip-with-linux-jre" depends="build,build-launchers,-download-linux-jre"
             description="Builds a ZIP distribution of the suite, launchers, and selected modules from the platform. This includes the JRE for Linux.">
         <mkdir dir="${dist.dir}"/>
         <!-- pathfileset does not support 'prefix' and 'filemode' parameters, we have to copy them to temp location -->
@@ -156,13 +215,11 @@
                  destdir="${build.launcher.dir}/etc/"
                  preservelastmodified="true"
                  eol="lf" />
-        
-        <!-- work around to get the modified help jars to the build -->
-        <copy file="${nbplatform.default.netbeans.dest.dir}/platform/modules/ext/jhall-2.0_05.jar" todir="${temp.dir.rest}/platform/modules/ext" verbose="true"/>
-        
+
+
         <!-- delete the harness folder which is only required for testing -->
         <delete dir="${temp.dir.rest}/harness"/>
-        
+
         <tar destfile="${dist.dir}/${dist.filename.linux}.tar">
             <!-- Using pre-built executable files that come with the Constellation icon -->
             <!--<tarfileset dir="${build.launcher.dir}/bin/" filemode="755" prefix="${app.name}/bin"/>-->

--- a/constellation/build.xml
+++ b/constellation/build.xml
@@ -155,6 +155,21 @@
                 <exclude name="${help.deploy.dir}/**"/>
             </fileset>
         </copy>
+        <copy todir="${dist.dir}/${dist.filename.macosx}/constellation-adaptors" overwrite="true" includeEmptyDirs="false">
+            <fileset dir="${basedir}\..\..\constellation-adaptors">
+                <include name="${help.toc.file}"/>
+                <include name="${help.bootstrap.dir}"/>
+                <include name="${help.docs.dir}/${help.type.md}"/>
+                <include name="${help.docs.dir}/${help.type.png}"/>
+                <include name="${help.docs.dir}/${help.type.jpg}"/>
+                <include name="${help.docs.resources.dir}/${help.type.md}"/>
+                <include name="${help.docs.resources.dir}/${help.type.png}"/>
+                <include name="${help.docs.resources.dir}/${help.type.jpg}"/>
+                <exclude name="docs/**"/>
+                <exclude name="**/build/**"/>
+                <exclude name="${help.deploy.dir}/**"/>
+            </fileset>
+        </copy>
 
         <tar destfile="${dist.dir}/${dist.filename.macosx}.tar">
             <!-- Using pre-built executable files that come with the Constellation icon -->
@@ -174,7 +189,7 @@
             <tarfileset dir="${basedir}/${jre.filename.macosx}/bin/" filemode="755" prefix="${app.name}/jre/bin" uid="${nobody}" gid="${nobody}"/>
 
             <tarfileset dir="${dist.dir}/${dist.filename.macosx}/${app.name}" prefix="${app.name}/${app.name}" uid="${nobody}" gid="${nobody}"/>
-
+            <tarfileset dir="${dist.dir}/${dist.filename.macosx}/constellation-adaptors" prefix="${app.name}/${app.name}-adaptors" uid="${nobody}" gid="${nobody}"/>
             <!-- Yes, the doubled app.name is a bit ugly, but better than the alternative; cf. #66441: -->
             <tarfileset dir="${cluster}" prefix="${app.name}/${app.name}" uid="${nobody}" gid="${nobody}">
                 <exclude name="config/Modules/*.xml_hidden"/>
@@ -184,6 +199,7 @@
         <delete file="${dist.dir}/${dist.filename.macosx}.tar"/>
         <delete dir="${basedir}/${jre.filename.macosx}/"/>
         <delete dir="${dist.dir}/${dist.filename.macosx}/${app.name}"/>
+        <delete dir="${dist.dir}/${dist.filename.macosx}/constellation-adaptors"/>
         <delete dir="${dist.dir}/${dist.filename.macosx}"/>
     </target>
 
@@ -217,8 +233,40 @@
                  eol="lf" />
 
 
-        <!-- delete the harness folder which is only required for testing -->
-        <delete dir="${temp.dir.rest}/harness"/>
+         <!-- delete the harness folder which is only required for testing -->
+         <delete dir="${temp.dir.rest}/harness"/>
+
+         <copy todir="${dist.dir}/${dist.filename.linux}/${app.name}" overwrite="true" includeEmptyDirs="false">
+             <fileset dir="${basedir}\..\..\${app.name}">
+                 <include name="${help.toc.file}"/>
+                 <include name="${help.bootstrap.dir}"/>
+                 <include name="${help.docs.dir}/${help.type.md}"/>
+                 <include name="${help.docs.dir}/${help.type.png}"/>
+                 <include name="${help.docs.dir}/${help.type.jpg}"/>
+                 <include name="${help.docs.resources.dir}/${help.type.md}"/>
+                 <include name="${help.docs.resources.dir}/${help.type.png}"/>
+                 <include name="${help.docs.resources.dir}/${help.type.jpg}"/>
+                 <exclude name="docs/**"/>
+                 <exclude name="**/build/**"/>
+                 <exclude name="${help.deploy.dir}/**"/>
+             </fileset>
+         </copy>
+         <copy todir="${dist.dir}/${dist.filename.linux}/constellation-adaptors" overwrite="true" includeEmptyDirs="false">
+             <fileset dir="${basedir}\..\..\constellation-adaptors">
+                 <include name="${help.toc.file}"/>
+                 <include name="${help.bootstrap.dir}"/>
+                 <include name="${help.docs.dir}/${help.type.md}"/>
+                 <include name="${help.docs.dir}/${help.type.png}"/>
+                 <include name="${help.docs.dir}/${help.type.jpg}"/>
+                 <include name="${help.docs.resources.dir}/${help.type.md}"/>
+                 <include name="${help.docs.resources.dir}/${help.type.png}"/>
+                 <include name="${help.docs.resources.dir}/${help.type.jpg}"/>
+                 <exclude name="docs/**"/>
+                 <exclude name="**/build/**"/>
+                 <exclude name="${help.deploy.dir}/**"/>
+             </fileset>
+         </copy>
+
 
         <tar destfile="${dist.dir}/${dist.filename.linux}.tar">
             <!-- Using pre-built executable files that come with the Constellation icon -->
@@ -236,7 +284,8 @@
                 <exclude name="bin/*"/>
             </tarfileset>
             <tarfileset dir="${basedir}/${jre.filename.linux}/bin/" filemode="755" prefix="${app.name}/jre/bin" uid="${nobody}" gid="${nobody}"/>
-
+            <tarfileset dir="${dist.dir}/${dist.filename.linux}/${app.name}" prefix="${app.name}/${app.name}" uid="${nobody}" gid="${nobody}"/>
+            <tarfileset dir="${dist.dir}/${dist.filename.linux}/constellation-adaptors" prefix="${app.name}/${app.name}-adaptors" uid="${nobody}" gid="${nobody}"/>
             <!-- Yes, the doubled app.name is a bit ugly, but better than the alternative; cf. #66441: -->
             <tarfileset dir="${cluster}" prefix="${app.name}/${app.name}" uid="${nobody}" gid="${nobody}">
                 <exclude name="config/Modules/*.xml_hidden"/>
@@ -245,6 +294,9 @@
         <gzip src="${dist.dir}/${dist.filename.linux}.tar" destfile="${dist.dir}/${dist.filename.linux}.tar.gz"/>
         <delete file="${dist.dir}/${dist.filename.linux}.tar"/>
         <delete dir="${basedir}/${jre.filename.linux}/"/>
+        <delete dir="${dist.dir}/${dist.filename.linux}/${app.name}"/>
+        <delete dir="${dist.dir}/${dist.filename.linux}/constellation-adaptors"/>
+        <delete dir="${dist.dir}/${dist.filename.linux}"/>
     </target>
 
 </project>


### PR DESCRIPTION
This Pr should only be merged in once the main Help PR is merged.  https://github.com/constellation-app/constellation/pull/1462
This PR allows the application to be built with help documentation as plain files as opposed to converted to jars.
- Removes the moving of old JHall Javahelp files
- Adds a step to grab all files from the relevant repositories and puts them within the zip files under `C:/Userdir/constellation-applications\constellation\dist\constellation-win-v2.3.0\constellation\constellation` or alternately constellation-adaptors depending on the source of the help files.
