### PR TITLE
Make sure "Error" and "Fatal" messages are shown to users

### DIFF
--- a/constellation-cyber/build.xml
+++ b/constellation-cyber/build.xml
@@ -5,7 +5,7 @@
     <import file="nbproject/build-impl.xml"/>
     
     <!-- build jre zips -->
-    <property name="dist.version" value="v1.2.0"/>
+    <property name="dist.version" value="v1.3.0"/>
     <property name="jre.filename.windows" value="zulu11.37.19-ca-fx-jre11.0.6-win_x64"/>
     <property name="jre.url.windows" value="https://cdn.azul.com/zulu/bin/${jre.filename.windows}.zip"/>
     <property name="jre.filename.macosx" value="zulu11.37.19-ca-fx-jre11.0.6-macosx_x64"/><!-- zulu11.39.15-ca-fx-jre11.0.7-macosx_x64 Azul distribution is broken -->

--- a/constellation-cyber/constellation.conf
+++ b/constellation-cyber/constellation.conf
@@ -1,5 +1,4 @@
-# Custom app.conf for CONSTELLATION
-#
+# Custom app.conf for Constellation Cyber
 
 # ${HOME} will be replaced by user home directory according to platform
 default_userdir="${HOME}/.${APPNAME}"
@@ -7,7 +6,7 @@ default_mac_userdir="${HOME}/Library/Application Support/${APPNAME}"
 
 # options used by the launcher by default, can be overridden by explicit
 # command line switches
-default_options="--branding ${branding.token} -J-Xms1g -J-Xmx4g -J-Dsun.java2d.opengl=false -J-Dsun.java2d.noddraw=true -J-Dsun.awt.nopixfmt=true -J-Dsun.awt.noerasebackground=true -J-Dnetbeans.openfile.197063=true -J-Dprism.dirtyopts=false -J-verbose:gc -J-Dau.gov.asd.tac.constellation.utilities.https.HttpsConnection.level=FINE -J-Djogamp.gluegen.UseTempJarCache=true -J-Dorg.netbeans.log.numberOfFiles=20"
+default_options="--branding ${branding.token} -J-Xms1g -J-Xmx4g -J-Dsun.java2d.opengl=false -J-Dsun.java2d.noddraw=true -J-Dsun.awt.nopixfmt=true -J-Dsun.awt.noerasebackground=true -J-Dnetbeans.openfile.197063=true -J-Dprism.dirtyopts=false -J-Dau.gov.asd.tac.constellation.utilities.https.HttpsConnection.level=FINE -J-Djogamp.gluegen.UseTempJarCache=true -J-Dorg.netbeans.log.numberOfFiles=20 -J-Dnetbeans.exception.report.min.level=1 -J-Dnetbeans.exception.alert.min.level=900"
 # for development purposes you may wish to append: -J-Dnetbeans.logger.console=true -J-ea
 
 # default location of JDK/JRE, can be overridden by using --jdkhome <dir> switch

--- a/constellation/build.xml
+++ b/constellation/build.xml
@@ -5,7 +5,7 @@
     <import file="nbproject/build-impl.xml"/>
 
     <!-- build jre zips -->
-    <property name="dist.version" value="v2.4.0-rc2"/>
+    <property name="dist.version" value="master-2021-09-14"/>
     <property name="jre.name" value="zulu11.37.19-ca-fx-jre11.0.6"/>
     <property name="jre.filename.windows" value="${jre.name}-win_x64"/>
     <property name="jre.url.windows" value="https://cdn.azul.com/zulu/bin/${jre.filename.windows}.zip"/>

--- a/constellation/build.xml
+++ b/constellation/build.xml
@@ -5,7 +5,7 @@
     <import file="nbproject/build-impl.xml"/>
 
     <!-- build jre zips -->
-    <property name="dist.version" value="master-2021-09-14"/>
+    <property name="dist.version" value="v2.4.0-rc2"/>
     <property name="jre.name" value="zulu11.37.19-ca-fx-jre11.0.6"/>
     <property name="jre.filename.windows" value="${jre.name}-win_x64"/>
     <property name="jre.url.windows" value="https://cdn.azul.com/zulu/bin/${jre.filename.windows}.zip"/>

--- a/constellation/constellation.conf
+++ b/constellation/constellation.conf
@@ -1,5 +1,4 @@
-# Custom app.conf for CONSTELLATION
-#
+# Custom app.conf for Constellation
 
 # ${HOME} will be replaced by user home directory according to platform
 default_userdir="${HOME}/.${APPNAME}"
@@ -7,7 +6,7 @@ default_mac_userdir="${HOME}/Library/Application Support/${APPNAME}"
 
 # options used by the launcher by default, can be overridden by explicit
 # command line switches
-default_options="--branding ${branding.token} -J-Xms1g -J-Xmx4g -J-Dsun.java2d.opengl=false -J-Dsun.java2d.noddraw=true -J-Dsun.awt.nopixfmt=true -J-Dsun.awt.noerasebackground=true -J-Dnetbeans.openfile.197063=true -J-Dprism.dirtyopts=false -J-verbose:gc -J-Dau.gov.asd.tac.constellation.utilities.https.HttpsConnection.level=FINE -J-Djogamp.gluegen.UseTempJarCache=true -J-Dorg.netbeans.log.numberOfFiles=20"
+default_options="--branding ${branding.token} -J-Xms1g -J-Xmx4g -J-Dsun.java2d.opengl=false -J-Dsun.java2d.noddraw=true -J-Dsun.awt.nopixfmt=true -J-Dsun.awt.noerasebackground=true -J-Dnetbeans.openfile.197063=true -J-Dprism.dirtyopts=false -J-Dau.gov.asd.tac.constellation.utilities.https.HttpsConnection.level=FINE -J-Djogamp.gluegen.UseTempJarCache=true -J-Dorg.netbeans.log.numberOfFiles=20 -J-Dnetbeans.exception.report.min.level=1 -J-Dnetbeans.exception.alert.min.level=900"
 # for development purposes you may wish to append: -J-Dnetbeans.logger.console=true -J-ea
 
 # default location of JDK/JRE, can be overridden by using --jdkhome <dir> switch


### PR DESCRIPTION
The error visibility improvement PR (https://github.com/constellation-app/constellation/pull/1459) requires the constellation-applications to be updated because there is a `constellation.conf` file here which is the version of the file that gets used when you build a zip version.