### PR TITLE
Rework Github Action

### DIFF
--- a/.github/workflows/release-build-cyber.yml
+++ b/.github/workflows/release-build-cyber.yml
@@ -8,73 +8,82 @@ on: workflow_dispatch
 jobs:
   create-release-build:
     runs-on: ubuntu-latest
+
     env:
-      RUNNER_IMAGE: "constellationapplication/netbeans-runner:12.0.4"
-      CYBER_VERSION: "v1.6.0"
-    container:
-      image: docker://pandoc/latex:2.9
-      options: --entrypoint=bash
+      VERSION: "v1.6.0"
+
     steps:
-      - name: Update GH Actions Tools 
-        run: |
-          apk update
-          apk upgrade
-          apk add --no-cache coreutils
-          apk add bash docker git sed
-      - name: Create Workspace Dir for operations
-        run: |
-              mkdir -p ./workspace
-      - name: Checkout Constellation repository
+      - name: Checkout Constellation Repository
         uses: actions/checkout@v2
         with:
           repository: constellation-app/constellation
-          path: ./workspace/constellation
-      - name: Checkout Constellation Adaptors repository
+          path: constellation
+
+      - name: Checkout Constellation Adaptors Repository
         uses: actions/checkout@v2
         with:
           repository: constellation-app/constellation-adaptors
-          path: ./workspace/constellation-adaptors
-      - name: Checkout Constellation Cyber repository
+          path: constellation-adaptors
+
+      - name: Checkout Constellation Cyber Repository
         uses: actions/checkout@v2
         with:
           repository: AustralianCyberSecurityCentre/constellation_cyber_plugins
-          path: ./workspace/constellation_cyber_plugins
-      - name: Checkout Constellation Applications repository
+          path: constellation_cyber_plugins
+
+      - name: Checkout Constellation Applications Repository
         uses: actions/checkout@v2
         with:
           repository: constellation-app/constellation-applications
-          path: ./workspace/constellation-applications
-      - name: Update Version Number
+          path: constellation-applications
+
+      - name: Update Version
         run: |
-               sed -i "s/(under development)/$CYBER_VERSION/" ./workspace/constellation/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/startup/Startup.java
-               sed 's/"Constellation";/"Constellation Cyber";/' ./workspace/constellation/CoreUtilities/src/au/gov/asd/tac/constellation/utilities/BrandingUtilities.java
+               sed -i "s/(under development)/$VERSION/" constellation/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/startup/Startup.java
+               sed 's/"Constellation";/"Constellation Cyber";/' constellation/CoreUtilities/src/au/gov/asd/tac/constellation/utilities/BrandingUtilities.java
+
+      # The module versions need to ideally be downgraded in AustralianCyberSecurityCentre/constellation_cyber_plugins via a PR
+      - name: Temporary Workaround
+        run: |
+               sed -i "s/9.15.1/9.15/" constellation_cyber_plugins/CyberImportExportPlugins/nbproject/project.xml
+               sed -i "s/8.41.1/8.41/" constellation_cyber_plugins/CyberImportExportPlugins/nbproject/project.xml
+               sed -i "s/9.16.1/9.16/" constellation_cyber_plugins/CyberImportExportPlugins/nbproject/project.xml
+
       - name: Add Execute Privilege to Scripts
         run: |
-              chmod +x ./workspace/constellation-applications/build-zip.sh
-              chmod +x ./workspace/constellation-applications/functions.sh
-      - name: Run build process within Docker container
-        run: |
-            docker pull "${RUNNER_IMAGE}"
-            docker run -e GIT_DISCOVERY_ACROSS_FILESYSTEM=1 \
-            --mount "type=bind,source=$(pwd),target=/code" \
-            --workdir /code/workspace/constellation-applications \
-            ${RUNNER_IMAGE} \
+              chmod +x constellation-applications/build-zip.sh
+              chmod +x constellation-applications/functions.sh
+
+      - uses: addnab/docker-run-action@v3
+        with:
+          image: constellationapplication/netbeans-runner:12.0.4
+          options: |
+            --volume ${{ github.workspace }}:/code 
+            --workdir /code/constellation-applications
+          run: |
             ./build-zip.sh -a constellation-cyber -m "constellation constellation-adaptors constellation_cyber_plugins"
+
+      - name: Show Built Releases
+        run: |
+              ls -l constellation-applications/constellation-cyber/dist
+
       - name: Upload Linux Build
         uses: actions/upload-artifact@v2.3.0
         with:
           name: Linux Release Build
-          path: ./workspace/constellation-applications/constellation-cyber/dist/constellation-linux**
-          retention-days: 2
+          path: constellation-applications/constellation-cyber/dist/constellation-linux**
+          retention-days: 1
+
       - name: Upload MacOS Build
         uses: actions/upload-artifact@v2.3.0
         with:
           name: MacOSX Release Build
-          path: ./workspace/constellation-applications/constellation-cyber/dist/constellation-macosx**
-          retention-days: 2
+          path: constellation-applications/constellation-cyber/dist/constellation-macosx**
+          retention-days: 1
+
       - name: Upload Windows Build
         uses: actions/upload-artifact@v2.3.0
         with:
           name: Windows Release Build
-          path: ./workspace/constellation-applications/constellation-cyber/dist/constellation-win**.zip
-          retention-days: 2
+          path: constellation-applications/constellation-cyber/dist/constellation-win**.zip
+          retention-days: 1

--- a/.github/workflows/release-build-cyber.yml
+++ b/.github/workflows/release-build-cyber.yml
@@ -39,33 +39,48 @@ jobs:
 
       - name: Update Version
         run: |
-               sed -i "s/(under development)/$VERSION/" constellation/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/startup/Startup.java
-               sed 's/"Constellation";/"Constellation Cyber";/' constellation/CoreUtilities/src/au/gov/asd/tac/constellation/utilities/BrandingUtilities.java
+          sed -i "s/(under development)/$VERSION/" constellation/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/startup/Startup.java
+          sed -i 's/"Constellation";/"Constellation Cyber";/' constellation/CoreUtilities/src/au/gov/asd/tac/constellation/utilities/BrandingUtilities.java
 
       # The module versions need to ideally be downgraded in AustralianCyberSecurityCentre/constellation_cyber_plugins via a PR
       - name: Temporary Workaround
         run: |
-               sed -i "s/9.15.1/9.15/" constellation_cyber_plugins/CyberImportExportPlugins/nbproject/project.xml
-               sed -i "s/8.41.1/8.41/" constellation_cyber_plugins/CyberImportExportPlugins/nbproject/project.xml
-               sed -i "s/9.16.1/9.16/" constellation_cyber_plugins/CyberImportExportPlugins/nbproject/project.xml
+          sed -i "s/9.15.1/9.15/" constellation_cyber_plugins/CyberImportExportPlugins/nbproject/project.xml
+          sed -i "s/8.41.1/8.41/" constellation_cyber_plugins/CyberImportExportPlugins/nbproject/project.xml
+          sed -i "s/9.16.1/9.16/" constellation_cyber_plugins/CyberImportExportPlugins/nbproject/project.xml
+
+      # Cache the ivy dependencies
+      - name: Restore Ivy Cache
+        id: cache-dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.ivy2
+          key: ${{ runner.os }}-ivy-${{ hashFiles('constellation/CoreDependencies/src/ivy.xml') }}
+
+      - name: Create Ivy Cache
+        if: steps.cache-dependencies.outputs.cache-hit != 'true'
+        run: |
+          mkdir ~/.ivy2
 
       - name: Add Execute Privilege to Scripts
         run: |
-              chmod +x constellation-applications/build-zip.sh
-              chmod +x constellation-applications/functions.sh
+          chmod +x constellation-applications/build-zip.sh
+          chmod +x constellation-applications/functions.sh
 
-      - uses: addnab/docker-run-action@v3
+      - name: Build Zips
+        uses: addnab/docker-run-action@v3
         with:
           image: constellationapplication/netbeans-runner:12.0.4
           options: |
             --volume ${{ github.workspace }}:/code 
+            --volume /home/runner/.ivy2:/root/.ivy2
             --workdir /code/constellation-applications
           run: |
             ./build-zip.sh -a constellation-cyber -m "constellation constellation-adaptors constellation_cyber_plugins"
 
       - name: Show Built Releases
         run: |
-              ls -l constellation-applications/constellation-cyber/dist
+          ls -l constellation-applications/constellation-cyber/dist
 
       - name: Upload Linux Build
         uses: actions/upload-artifact@v2.3.0


### PR DESCRIPTION
@antares1470 I've spent the afternoon looking at how GitHub actions work in more detail and I have reworked the action based on my new understanding. I played around with actions in my local area (https://github.com/arcturus2/actions/actions) to avoid spamming this repo with dirty commits.

Anyway, the updated version works and here are the changes in a summary:

This release build action was actually running everything inside the docker image `pandoc/latex:2.9` which is pointless. I have removed this nested container which complicates things. For instance if you look at the logs of previous runs in this repo's actions the working folder is `__w` which is something GitHub actions does for us to mount the current directory to be accessible inside the nested docker image (in this case the pandoc image).

The change firstly makes sure that we are running just on the ubuntu image directly and we also don't need to install anything like `docker`, `git`, `sed` etc as there are better ways to do this. Not having to install linux packages also saved time.

I have removed the extra `./workspace` folder requirement and just let the checkouts, checkout to the "working" directory which is controlled by `${{ github.workspace }}`. I have also learnt that it is way better to use variables than hard code folders like the original version did which was pointing to `/home/runner/work/constellation`. This is because GitHub Actions can change things and it will break our action making everything fragile.

I also realised the possible reason why this cyber release was not working even though it was a copy paste from the release action in constellation-app/constellation. It has to do with the folder path name linked to the repository name. In theory if we changed the code to also point to `/home/runner/work/constellation-applications` it would have worked perhaps???

I've utilised a GitHub action called `addnab/docker-run-action@v3` to run docker images which avoids the need to install docker. This option looks cleaner as well and I learnt about it in https://aschmelyun.com/blog/using-docker-run-inside-of-github-actions/ blog.

One problem I found with the Cyber release was that they are using a slightly newer version of Netbeans to build their module which fails for us so I have added a temporary step to reduce the version number of 3 modules. See the "Temporary Workaround" step to what I changed via a simple `sed` command. I think we can either PR a change to drop that version in the Cyber repo or just leave it for now. When we go to NetBeans 13 this won't be an issue.

I will do a similar fix for the action in constellation-app/constellation now to make sure they are in sync.

