### PR TITLE
build scripts update

### DIFF
--- a/constellation-cyber/build.xml
+++ b/constellation-cyber/build.xml
@@ -17,17 +17,6 @@
     <property name="dist.filename.macosx" value="constellation-cyber-macosx-${dist.version}"/>
     <property name="nobody" value="65534"/>
 
-    <property name="help.deploy.dir" value="dist/constellation_cyber_plugins"/>
-    <property name="help.docs.dir" value="**/docs"/>
-    <property name="help.docs.resources.dir" value="**/docs/resources"/>
-    <property name="help.type.md" value="**.md"/>
-    <property name="help.type.png" value="**.png"/>
-    <property name="help.type.jpg" value="**.jpg"/>
-    <property name="help.bootstrap.dir" value="bootstrap/**"/>
-    <property name="help.toc.file" value="toc.md"/>
-    <property name="help.toc.modulefile" value="**-toc.xml"/>
-
-
     <!-- Windows Section -->
 
     <target name="-download-windows-jre" >
@@ -55,52 +44,6 @@
                  preservelastmodified="true"
                  eol="crlf" />
 
-        <copy todir="${dist.dir}/${app.name}" overwrite="true" includeEmptyDirs="false">
-            <fileset dir="${basedir}\..\..\constellation">
-                <include name="${help.toc.file}"/>
-                <include name="${help.bootstrap.dir}"/>
-                <include name="${help.docs.dir}/${help.type.md}"/>
-                <include name="${help.docs.dir}/${help.type.png}"/>
-                <include name="${help.docs.dir}/${help.type.jpg}"/>
-                <include name="${help.docs.dir}/${help.toc.modulefile}"/>
-                <include name="${help.docs.resources.dir}/${help.type.md}"/>
-                <include name="${help.docs.resources.dir}/${help.type.png}"/>
-                <include name="${help.docs.resources.dir}/${help.type.jpg}"/>
-                <exclude name="docs/**"/>
-                <exclude name="**/build/**"/>
-                <exclude name="${help.deploy.dir}/**"/>
-            </fileset>
-        </copy>
-        <copy todir="${dist.dir}/${app.name}-adaptors" overwrite="true" includeEmptyDirs="false">
-            <fileset dir="${basedir}\..\..\constellation-adaptors">
-                <include name="${help.toc.file}"/>
-                <include name="${help.bootstrap.dir}"/>
-                <include name="${help.docs.dir}/${help.type.md}"/>
-                <include name="${help.docs.dir}/${help.type.png}"/>
-                <include name="${help.docs.dir}/${help.type.jpg}"/>
-                <include name="${help.docs.dir}/${help.toc.modulefile}"/>
-                <include name="${help.docs.resources.dir}/${help.type.md}"/>
-                <include name="${help.docs.resources.dir}/${help.type.png}"/>
-                <include name="${help.docs.resources.dir}/${help.type.jpg}"/>
-                <exclude name="docs/**"/>
-                <exclude name="**/build/**"/>
-                <exclude name="${help.deploy.dir}/**"/>
-            </fileset>
-        </copy>
-        <copy todir="${help.deploy.dir}" verbose="true" overwrite="true" includeEmptyDirs="false">
-            <fileset dir="${basedir}\..\..\constellation_cyber_plugins">
-                <include name="${help.docs.dir}/${help.type.md}"/>
-                <include name="${help.docs.dir}/${help.type.png}"/>
-                <include name="${help.docs.dir}/${help.type.jpg}"/>
-                <include name="${help.docs.dir}/${help.toc.modulefile}"/>
-                <include name="${help.docs.resources.dir}/${help.type.md}"/>
-                <include name="${help.docs.resources.dir}/${help.type.png}"/>
-                <include name="${help.docs.resources.dir}/${help.type.jpg}"/>
-                <exclude name="**/build/**"/>
-                <exclude name="dist/**"/>
-            </fileset>
-        </copy>
-
         <!-- delete the harness folder which is only required for testing -->
         <delete dir="${temp.dir.rest}/harness"/>
 
@@ -112,20 +55,12 @@
             <zipfileset dir="${temp.dir.nbexec}" filemode="755" prefix="${app.name}"/>
             <zipfileset dir="${temp.dir.rest}" prefix="${app.name}"/>
             <zipfileset dir="${basedir}/${jre.filename.windows}/" prefix="${app.name}/jre"/>
-            <zipfileset dir="${help.deploy.dir}" prefix="constellation/constellation_cyber_plugins"/>
-            <zipfileset dir="${dist.dir}/${app.name}" prefix="constellation/constellation"/>
-            <zipfileset dir="${dist.dir}/${app.name}-adaptors" prefix="constellation/constellation-adaptors"/>
             <!-- Yes, the doubled app.name is a bit ugly, but better than the alternative; cf. #66441: -->
             <zipfileset dir="${cluster}" prefix="${app.name}/${app.name}">
                 <exclude name="config/Modules/*.xml_hidden"/>
             </zipfileset>
         </zip>
         <delete dir="${basedir}/${jre.filename.windows}/"/>
-        <delete dir="${help.deploy.dir}/constellation_cyber_plugins"/>
-        <delete dir="dist/constellation_cyber_plugins"/>
-        <delete dir="${help.deploy.dir}"/>
-        <delete dir="${dist.dir}/${app.name}"/>
-        <delete dir="${dist.dir}/${app.name}-adaptors"/>
     </target>
 
     <!-- MacOSX Section -->
@@ -157,53 +92,6 @@
                  preservelastmodified="true"
                  eol="lf" />
 
-
-        <copy todir="${dist.dir}/${app.name}" overwrite="true" includeEmptyDirs="false">
-            <fileset dir="${basedir}\..\..\constellation">
-                <include name="${help.toc.file}"/>
-                <include name="${help.bootstrap.dir}"/>
-                <include name="${help.docs.dir}/${help.type.md}"/>
-                <include name="${help.docs.dir}/${help.type.png}"/>
-                <include name="${help.docs.dir}/${help.type.jpg}"/>
-                <include name="${help.docs.dir}/${help.toc.modulefile}"/>
-                <include name="${help.docs.resources.dir}/${help.type.md}"/>
-                <include name="${help.docs.resources.dir}/${help.type.png}"/>
-                <include name="${help.docs.resources.dir}/${help.type.jpg}"/>
-                <exclude name="docs/**"/>
-                <exclude name="**/build/**"/>
-                <exclude name="${help.deploy.dir}/**"/>
-            </fileset>
-        </copy>
-        <copy todir="${dist.dir}/${app.name}-adaptors" overwrite="true" includeEmptyDirs="false">
-            <fileset dir="${basedir}\..\..\constellation-adaptors">
-                <include name="${help.toc.file}"/>
-                <include name="${help.bootstrap.dir}"/>
-                <include name="${help.docs.dir}/${help.type.md}"/>
-                <include name="${help.docs.dir}/${help.type.png}"/>
-                <include name="${help.docs.dir}/${help.type.jpg}"/>
-                <include name="${help.docs.dir}/${help.toc.modulefile}"/>
-                <include name="${help.docs.resources.dir}/${help.type.md}"/>
-                <include name="${help.docs.resources.dir}/${help.type.png}"/>
-                <include name="${help.docs.resources.dir}/${help.type.jpg}"/>
-                <exclude name="docs/**"/>
-                <exclude name="**/build/**"/>
-                <exclude name="${help.deploy.dir}/**"/>
-            </fileset>
-        </copy>
-        <copy todir="${help.deploy.dir}" verbose="true" overwrite="true" includeEmptyDirs="false">
-            <fileset dir="${basedir}\..\..\constellation_cyber_plugins">
-                <include name="${help.docs.dir}/${help.type.md}"/>
-                <include name="${help.docs.dir}/${help.type.png}"/>
-                <include name="${help.docs.dir}/${help.type.jpg}"/>
-                <include name="${help.docs.dir}/${help.toc.modulefile}"/>
-                <include name="${help.docs.resources.dir}/${help.type.md}"/>
-                <include name="${help.docs.resources.dir}/${help.type.png}"/>
-                <include name="${help.docs.resources.dir}/${help.type.jpg}"/>
-                <exclude name="**/build/**"/>
-                <exclude name="dist/**"/>
-            </fileset>
-        </copy>
-
         <!-- delete the harness folder which is only required for testing -->
         <delete dir="${temp.dir.rest}/harness"/>
 
@@ -223,9 +111,6 @@
                 <exclude name="bin/*"/>
             </tarfileset>
             <tarfileset dir="${basedir}/${jre.filename.macosx}/bin/" filemode="755" prefix="${app.name}/jre/bin" uid="${nobody}" gid="${nobody}"/>
-            <tarfileset dir="${help.deploy.dir}" prefix="constellation/constellation_cyber_plugins" uid="${nobody}" gid="${nobody}"/>
-            <tarfileset dir="${dist.dir}/${app.name}" prefix="constellation/constellation" uid="${nobody}" gid="${nobody}"/>
-            <tarfileset dir="${dist.dir}/${app.name}-adaptors" prefix="constellation/constellation-adaptors" uid="${nobody}" gid="${nobody}"/>
             <!-- Yes, the doubled app.name is a bit ugly, but better than the alternative; cf. #66441: -->
             <tarfileset dir="${cluster}" prefix="${app.name}/${app.name}" uid="${nobody}" gid="${nobody}">
                 <exclude name="config/Modules/*.xml_hidden"/>
@@ -234,11 +119,6 @@
         <gzip src="${dist.dir}/${dist.filename.macosx}.tar" destfile="${dist.dir}/${dist.filename.macosx}.tar.gz"/>
         <delete file="${dist.dir}/${dist.filename.macosx}.tar"/>
         <delete dir="${basedir}/${jre.filename.macosx}/"/>
-        <delete dir="${help.deploy.dir}/constellation_cyber_plugins"/>
-        <delete dir="dist/constellation_cyber_plugins"/>
-        <delete dir="${help.deploy.dir}"/>
-        <delete dir="${dist.dir}/${app.name}"/>
-        <delete dir="${dist.dir}/${app.name}-adaptors"/>
     </target>
 
     <!-- Linux Section -->
@@ -270,53 +150,6 @@
                  preservelastmodified="true"
                  eol="lf" />
 
-
-        <copy todir="${dist.dir}/${app.name}" overwrite="true" includeEmptyDirs="false">
-            <fileset dir="${basedir}\..\..\constellation">
-                <include name="${help.toc.file}"/>
-                <include name="${help.bootstrap.dir}"/>
-                <include name="${help.docs.dir}/${help.type.md}"/>
-                <include name="${help.docs.dir}/${help.type.png}"/>
-                <include name="${help.docs.dir}/${help.type.jpg}"/>
-                <include name="${help.docs.dir}/${help.toc.modulefile}"/>
-                <include name="${help.docs.resources.dir}/${help.type.md}"/>
-                <include name="${help.docs.resources.dir}/${help.type.png}"/>
-                <include name="${help.docs.resources.dir}/${help.type.jpg}"/>
-                <exclude name="docs/**"/>
-                <exclude name="**/build/**"/>
-                <exclude name="${help.deploy.dir}/**"/>
-            </fileset>
-        </copy>
-        <copy todir="${dist.dir}/${app.name}-adaptors" overwrite="true" includeEmptyDirs="false">
-            <fileset dir="${basedir}\..\..\constellation-adaptors">
-                <include name="${help.toc.file}"/>
-                <include name="${help.bootstrap.dir}"/>
-                <include name="${help.docs.dir}/${help.type.md}"/>
-                <include name="${help.docs.dir}/${help.type.png}"/>
-                <include name="${help.docs.dir}/${help.type.jpg}"/>
-                <include name="${help.docs.dir}/${help.toc.modulefile}"/>
-                <include name="${help.docs.resources.dir}/${help.type.md}"/>
-                <include name="${help.docs.resources.dir}/${help.type.png}"/>
-                <include name="${help.docs.resources.dir}/${help.type.jpg}"/>
-                <exclude name="docs/**"/>
-                <exclude name="**/build/**"/>
-                <exclude name="${help.deploy.dir}/**"/>
-            </fileset>
-        </copy>
-        <copy todir="${help.deploy.dir}" verbose="true" overwrite="true" includeEmptyDirs="false">
-            <fileset dir="${basedir}\..\..\constellation_cyber_plugins">
-                <include name="${help.docs.dir}/${help.type.md}"/>
-                <include name="${help.docs.dir}/${help.type.png}"/>
-                <include name="${help.docs.dir}/${help.type.jpg}"/>
-                <include name="${help.docs.dir}/${help.toc.modulefile}"/>
-                <include name="${help.docs.resources.dir}/${help.type.md}"/>
-                <include name="${help.docs.resources.dir}/${help.type.png}"/>
-                <include name="${help.docs.resources.dir}/${help.type.jpg}"/>
-                <exclude name="**/build/**"/>
-                <exclude name="dist/**"/>
-            </fileset>
-        </copy>
-
         <!-- delete the harness folder which is only required for testing -->
         <delete dir="${temp.dir.rest}/harness"/>
 
@@ -336,9 +169,6 @@
                 <exclude name="bin/*"/>
             </tarfileset>
             <tarfileset dir="${basedir}/${jre.filename.linux}/bin/" filemode="755" prefix="${app.name}/jre/bin" uid="${nobody}" gid="${nobody}"/>
-            <tarfileset dir="${help.deploy.dir}" prefix="constellation/constellation_cyber_plugins" uid="${nobody}" gid="${nobody}"/>
-            <tarfileset dir="${dist.dir}/${app.name}" prefix="constellation/constellation" uid="${nobody}" gid="${nobody}"/>
-            <tarfileset dir="${dist.dir}/${app.name}-adaptors" prefix="constellation/constellation-adaptors" uid="${nobody}" gid="${nobody}"/>
             <!-- Yes, the doubled app.name is a bit ugly, but better than the alternative; cf. #66441: -->
             <tarfileset dir="${cluster}" prefix="${app.name}/${app.name}" uid="${nobody}" gid="${nobody}">
                 <exclude name="config/Modules/*.xml_hidden"/>
@@ -347,11 +177,6 @@
         <gzip src="${dist.dir}/${dist.filename.linux}.tar" destfile="${dist.dir}/${dist.filename.linux}.tar.gz"/>
         <delete file="${dist.dir}/${dist.filename.linux}.tar"/>
         <delete dir="${basedir}/${jre.filename.linux}/"/>
-        <delete dir="${help.deploy.dir}/constellation_cyber_plugins"/>
-        <delete dir="dist/constellation_cyber_plugins"/>
-        <delete dir="${help.deploy.dir}"/>
-        <delete dir="${dist.dir}/${app.name}"/>
-        <delete dir="${dist.dir}/${app.name}-adaptors"/>
     </target>
 
 </project>

--- a/constellation/build.xml
+++ b/constellation/build.xml
@@ -18,16 +18,6 @@
     <property name="dist.filename.macosx" value="constellation-macosx-${dist.version}"/>
     <property name="nobody" value="65534"/>
 
-    <property name="help.deploy.dir" value="dist/constellation/constellation"/>
-    <property name="help.docs.dir" value="**/docs"/>
-    <property name="help.docs.resources.dir" value="**/docs/resources"/>
-    <property name="help.type.md" value="**.md"/>
-    <property name="help.type.png" value="**.png"/>
-    <property name="help.type.jpg" value="**.jpg"/>
-    <property name="help.bootstrap.dir" value="bootstrap/**"/>
-    <property name="help.toc.file" value="toc.md"/>
-    <property name="help.toc.modulefile" value="**-toc.xml"/>
-
     <!-- Windows Section -->
 
     <target name="-download-windows-jre" >
@@ -58,39 +48,6 @@
         <!-- delete the harness folder which is only required for testing -->
         <delete dir="${temp.dir.rest}/harness"/>
 
-        <copy todir="${dist.dir}/${dist.filename.windows}/${app.name}" overwrite="true" includeEmptyDirs="false">
-            <fileset dir="${basedir}\..\..\${app.name}">
-                <include name="${help.toc.file}"/>
-                <include name="${help.bootstrap.dir}"/>
-                <include name="${help.docs.dir}/${help.type.md}"/>
-                <include name="${help.docs.dir}/${help.type.png}"/>
-                <include name="${help.docs.dir}/${help.type.jpg}"/>
-                <include name="${help.docs.dir}/${help.toc.modulefile}"/>
-                <include name="${help.docs.resources.dir}/${help.type.md}"/>
-                <include name="${help.docs.resources.dir}/${help.type.png}"/>
-                <include name="${help.docs.resources.dir}/${help.type.jpg}"/>
-                <exclude name="docs/**"/>
-                <exclude name="**/build/**"/>
-                <exclude name="${help.deploy.dir}/**"/>
-            </fileset>
-        </copy>
-        <copy todir="${dist.dir}/${dist.filename.windows}/constellation-adaptors" overwrite="true" includeEmptyDirs="false">
-            <fileset dir="${basedir}\..\..\constellation-adaptors">
-                <include name="${help.toc.file}"/>
-                <include name="${help.bootstrap.dir}"/>
-                <include name="${help.docs.dir}/${help.type.md}"/>
-                <include name="${help.docs.dir}/${help.type.png}"/>
-                <include name="${help.docs.dir}/${help.type.jpg}"/>
-                <include name="${help.docs.dir}/${help.toc.modulefile}"/>
-                <include name="${help.docs.resources.dir}/${help.type.md}"/>
-                <include name="${help.docs.resources.dir}/${help.type.png}"/>
-                <include name="${help.docs.resources.dir}/${help.type.jpg}"/>
-                <exclude name="docs/**"/>
-                <exclude name="**/build/**"/>
-                <exclude name="${help.deploy.dir}/**"/>
-            </fileset>
-        </copy>
-
         <zip destfile="${dist.dir}/${dist.filename.windows}.zip">
             <!-- Using pre-built executable files that come with the Constellation icon -->
             <!--<zipfileset dir="${build.launcher.dir}/bin/" filemode="755" prefix="${app.name}/bin"/>-->
@@ -99,17 +56,12 @@
             <zipfileset dir="${temp.dir.nbexec}" filemode="755" prefix="${app.name}"/>
             <zipfileset dir="${temp.dir.rest}" prefix="${app.name}"/>
             <zipfileset dir="${basedir}/${jre.filename.windows}/" prefix="${app.name}/jre"/>
-            <zipfileset dir="${dist.dir}/${dist.filename.windows}/${app.name}" prefix="${app.name}/${app.name}"/>
-            <zipfileset dir="${dist.dir}/${dist.filename.windows}/constellation-adaptors" prefix="${app.name}/${app.name}-adaptors"/>
             <!-- Yes, the doubled app.name is a bit ugly, but better than the alternative; cf. #66441: -->
             <zipfileset dir="${cluster}" prefix="${app.name}/${app.name}">
                 <exclude name="config/Modules/*.xml_hidden"/>
             </zipfileset>
         </zip>
         <delete dir="${basedir}/${jre.filename.windows}/"/>
-        <delete dir="${dist.dir}/${dist.filename.windows}/${app.name}"/>
-        <delete dir="${dist.dir}/${dist.filename.windows}/constellation-adaptors"/>
-        <delete dir="${dist.dir}/${dist.filename.windows}"/>
     </target>
 
     <!-- MacOSX Section -->
@@ -144,39 +96,6 @@
         <!-- delete the harness folder which is only required for testing -->
         <delete dir="${temp.dir.rest}/harness"/>
 
-        <copy todir="${dist.dir}/${dist.filename.macosx}/${app.name}" overwrite="true" includeEmptyDirs="false">
-            <fileset dir="${basedir}\..\..\${app.name}">
-                <include name="${help.toc.file}"/>
-                <include name="${help.bootstrap.dir}"/>
-                <include name="${help.docs.dir}/${help.type.md}"/>
-                <include name="${help.docs.dir}/${help.type.png}"/>
-                <include name="${help.docs.dir}/${help.type.jpg}"/>
-                <include name="${help.docs.dir}/${help.toc.modulefile}"/>
-                <include name="${help.docs.resources.dir}/${help.type.md}"/>
-                <include name="${help.docs.resources.dir}/${help.type.png}"/>
-                <include name="${help.docs.resources.dir}/${help.type.jpg}"/>
-                <exclude name="docs/**"/>
-                <exclude name="**/build/**"/>
-                <exclude name="${help.deploy.dir}/**"/>
-            </fileset>
-        </copy>
-        <copy todir="${dist.dir}/${dist.filename.macosx}/constellation-adaptors" overwrite="true" includeEmptyDirs="false">
-            <fileset dir="${basedir}\..\..\constellation-adaptors">
-                <include name="${help.toc.file}"/>
-                <include name="${help.bootstrap.dir}"/>
-                <include name="${help.docs.dir}/${help.type.md}"/>
-                <include name="${help.docs.dir}/${help.type.png}"/>
-                <include name="${help.docs.dir}/${help.type.jpg}"/>
-                <include name="${help.docs.dir}/${help.toc.modulefile}"/>
-                <include name="${help.docs.resources.dir}/${help.type.md}"/>
-                <include name="${help.docs.resources.dir}/${help.type.png}"/>
-                <include name="${help.docs.resources.dir}/${help.type.jpg}"/>
-                <exclude name="docs/**"/>
-                <exclude name="**/build/**"/>
-                <exclude name="${help.deploy.dir}/**"/>
-            </fileset>
-        </copy>
-
         <tar destfile="${dist.dir}/${dist.filename.macosx}.tar">
             <!-- Using pre-built executable files that come with the Constellation icon -->
             <!--<tarfileset dir="${build.launcher.dir}/bin/" filemode="755" prefix="${app.name}/bin"/>-->
@@ -194,8 +113,6 @@
             </tarfileset>
             <tarfileset dir="${basedir}/${jre.filename.macosx}/bin/" filemode="755" prefix="${app.name}/jre/bin" uid="${nobody}" gid="${nobody}"/>
 
-            <tarfileset dir="${dist.dir}/${dist.filename.macosx}/${app.name}" prefix="${app.name}/${app.name}" uid="${nobody}" gid="${nobody}"/>
-            <tarfileset dir="${dist.dir}/${dist.filename.macosx}/constellation-adaptors" prefix="${app.name}/${app.name}-adaptors" uid="${nobody}" gid="${nobody}"/>
             <!-- Yes, the doubled app.name is a bit ugly, but better than the alternative; cf. #66441: -->
             <tarfileset dir="${cluster}" prefix="${app.name}/${app.name}" uid="${nobody}" gid="${nobody}">
                 <exclude name="config/Modules/*.xml_hidden"/>
@@ -204,9 +121,6 @@
         <gzip src="${dist.dir}/${dist.filename.macosx}.tar" destfile="${dist.dir}/${dist.filename.macosx}.tar.gz"/>
         <delete file="${dist.dir}/${dist.filename.macosx}.tar"/>
         <delete dir="${basedir}/${jre.filename.macosx}/"/>
-        <delete dir="${dist.dir}/${dist.filename.macosx}/${app.name}"/>
-        <delete dir="${dist.dir}/${dist.filename.macosx}/constellation-adaptors"/>
-        <delete dir="${dist.dir}/${dist.filename.macosx}"/>
     </target>
 
     <!-- Linux Section -->
@@ -242,40 +156,6 @@
         <!-- delete the harness folder which is only required for testing -->
         <delete dir="${temp.dir.rest}/harness"/>
 
-        <copy todir="${dist.dir}/${dist.filename.linux}/${app.name}" overwrite="true" includeEmptyDirs="false">
-            <fileset dir="${basedir}\..\..\${app.name}">
-                <include name="${help.toc.file}"/>
-                <include name="${help.bootstrap.dir}"/>
-                <include name="${help.docs.dir}/${help.type.md}"/>
-                <include name="${help.docs.dir}/${help.type.png}"/>
-                <include name="${help.docs.dir}/${help.type.jpg}"/>
-                <include name="${help.docs.dir}/${help.toc.modulefile}"/>
-                <include name="${help.docs.resources.dir}/${help.type.md}"/>
-                <include name="${help.docs.resources.dir}/${help.type.png}"/>
-                <include name="${help.docs.resources.dir}/${help.type.jpg}"/>
-                <exclude name="docs/**"/>
-                <exclude name="**/build/**"/>
-                <exclude name="${help.deploy.dir}/**"/>
-            </fileset>
-        </copy>
-        <copy todir="${dist.dir}/${dist.filename.linux}/constellation-adaptors" overwrite="true" includeEmptyDirs="false">
-            <fileset dir="${basedir}\..\..\constellation-adaptors">
-                <include name="${help.toc.file}"/>
-                <include name="${help.bootstrap.dir}"/>
-                <include name="${help.docs.dir}/${help.type.md}"/>
-                <include name="${help.docs.dir}/${help.type.png}"/>
-                <include name="${help.docs.dir}/${help.type.jpg}"/>
-                <include name="${help.docs.dir}/${help.toc.modulefile}"/>
-                <include name="${help.docs.resources.dir}/${help.type.md}"/>
-                <include name="${help.docs.resources.dir}/${help.type.png}"/>
-                <include name="${help.docs.resources.dir}/${help.type.jpg}"/>
-                <exclude name="docs/**"/>
-                <exclude name="**/build/**"/>
-                <exclude name="${help.deploy.dir}/**"/>
-            </fileset>
-        </copy>
-
-
         <tar destfile="${dist.dir}/${dist.filename.linux}.tar">
             <!-- Using pre-built executable files that come with the Constellation icon -->
             <!--<tarfileset dir="${build.launcher.dir}/bin/" filemode="755" prefix="${app.name}/bin"/>-->
@@ -292,8 +172,6 @@
                 <exclude name="bin/*"/>
             </tarfileset>
             <tarfileset dir="${basedir}/${jre.filename.linux}/bin/" filemode="755" prefix="${app.name}/jre/bin" uid="${nobody}" gid="${nobody}"/>
-            <tarfileset dir="${dist.dir}/${dist.filename.linux}/${app.name}" prefix="${app.name}/${app.name}" uid="${nobody}" gid="${nobody}"/>
-            <tarfileset dir="${dist.dir}/${dist.filename.linux}/constellation-adaptors" prefix="${app.name}/${app.name}-adaptors" uid="${nobody}" gid="${nobody}"/>
             <!-- Yes, the doubled app.name is a bit ugly, but better than the alternative; cf. #66441: -->
             <tarfileset dir="${cluster}" prefix="${app.name}/${app.name}" uid="${nobody}" gid="${nobody}">
                 <exclude name="config/Modules/*.xml_hidden"/>
@@ -302,9 +180,6 @@
         <gzip src="${dist.dir}/${dist.filename.linux}.tar" destfile="${dist.dir}/${dist.filename.linux}.tar.gz"/>
         <delete file="${dist.dir}/${dist.filename.linux}.tar"/>
         <delete dir="${basedir}/${jre.filename.linux}/"/>
-        <delete dir="${dist.dir}/${dist.filename.linux}/${app.name}"/>
-        <delete dir="${dist.dir}/${dist.filename.linux}/constellation-adaptors"/>
-        <delete dir="${dist.dir}/${dist.filename.linux}"/>
     </target>
 
 </project>


### PR DESCRIPTION
with help pages being moved in repos to the ext folders, there is no longer a need to explicitly copy the help pages. So removing the parts associated with doing so (as identified by previous commits which put them there)