### PR TITLE
switched build script to download zip macosx

### DIFF
--- a/constellation-cyber/build.xml
+++ b/constellation-cyber/build.xml
@@ -8,8 +8,8 @@
     <property name="dist.version" value="v3.0.0-alpha"/>
     <property name="jre.filename.windows" value="zulu21.32.17-ca-fx-jre21.0.2-win_x64"/>
     <property name="jre.url.windows" value="https://cdn.azul.com/zulu/bin/${jre.filename.windows}.zip"/>
-    <property name="jre.filename.macosx" value="zulu21.32.17-ca-fx-jre21.0.2-macosx_x64"/><!-- zulu11.39.15-ca-fx-jre11.0.7-macosx_x64 Azul distribution is broken -->
-    <property name="jre.url.macosx" value="https://cdn.azul.com/zulu/bin/${jre.filename.macosx}.tar.gz"/>
+    <property name="jre.filename.macosx" value="zulu21.32.17-ca-fx-jre21.0.2-macosx_x64"/>
+    <property name="jre.url.macosx" value="https://cdn.azul.com/zulu/bin/${jre.filename.macosx}.zip"/>
     <property name="jre.filename.linux" value="zulu21.32.17-ca-fx-jre21.0.2-linux_x64"/>
     <property name="jre.url.linux" value="https://cdn.azul.com/zulu/bin/${jre.filename.linux}.tar.gz"/>
     <property name="dist.filename.linux" value="constellation-cyber-linux-${dist.version}"/>
@@ -70,8 +70,8 @@
         <echo message="downloading JRE..."/>
         <get src="${jre.url.macosx}"
              dest="${basedir}" usetimestamp="true"/>
-        <untar src="${basedir}/${jre.filename.macosx}.tar.gz" dest="${basedir}" compression="gzip"/>
-        <delete file="${basedir}/${jre.filename.macosx}.tar.gz"/>
+        <unzip src="${basedir}/${jre.filename.macosx}.zip" dest="${basedir}"/>
+        <delete file="${basedir}/${jre.filename.macosx}.zip"/>
     </target>
 
     <!-- This is a copy of build-zip-with-windows-jre", if there is a better way to do this then let me know -->

--- a/constellation-cyber/build.xml
+++ b/constellation-cyber/build.xml
@@ -70,7 +70,9 @@
         <echo message="downloading JRE..."/>
         <get src="${jre.url.macosx}"
              dest="${basedir}" usetimestamp="true"/>
-        <unzip src="${basedir}/${jre.filename.macosx}.zip" dest="${basedir}"/>
+        <exec executable="unzip">
+            <arg value="${basedir}/${jre.filename.macosx}.zip"/>
+        </exec>
         <delete file="${basedir}/${jre.filename.macosx}.zip"/>
     </target>
 

--- a/constellation/build.xml
+++ b/constellation/build.xml
@@ -10,7 +10,7 @@
     <property name="jre.filename.windows" value="${jre.name}-win_x64"/>
     <property name="jre.url.windows" value="https://cdn.azul.com/zulu/bin/${jre.filename.windows}.zip"/>
     <property name="jre.filename.macosx" value="${jre.name}-macosx_x64"/>
-    <property name="jre.url.macosx" value="https://cdn.azul.com/zulu/bin/${jre.filename.macosx}.tar.gz"/>
+    <property name="jre.url.macosx" value="https://cdn.azul.com/zulu/bin/${jre.filename.macosx}.zip"/>
     <property name="jre.filename.linux" value="${jre.name}-linux_x64"/>
     <property name="jre.url.linux" value="https://cdn.azul.com/zulu/bin/${jre.filename.linux}.tar.gz"/>
     <property name="dist.filename.linux" value="constellation-linux-${dist.version}"/>
@@ -71,8 +71,8 @@
         <echo message="downloading JRE..."/>
         <get src="${jre.url.macosx}"
              dest="${basedir}" usetimestamp="true"/>
-        <untar src="${basedir}/${jre.filename.macosx}.tar.gz" dest="${basedir}" compression="gzip"/>
-        <delete file="${basedir}/${jre.filename.macosx}.tar.gz"/>
+		<unzip src="${basedir}/${jre.filename.macosx}.zip" dest="${basedir}"/>
+        <delete file="${basedir}/${jre.filename.macosx}.zip"/>
     </target>
 
     <!-- This is a copy of build-zip-with-windows-jre", if there is a better way to do this then let me know -->

--- a/constellation/build.xml
+++ b/constellation/build.xml
@@ -71,7 +71,9 @@
         <echo message="downloading JRE..."/>
         <get src="${jre.url.macosx}"
              dest="${basedir}" usetimestamp="true"/>
-		<unzip src="${basedir}/${jre.filename.macosx}.zip" dest="${basedir}"/>
+		<exec executable="unzip">
+            <arg value="${basedir}/${jre.filename.macosx}.zip"/>
+        </exec>
         <delete file="${basedir}/${jre.filename.macosx}.zip"/>
     </target>
 


### PR DESCRIPTION
the tar.gz instance for azul jdk macosx appears to be broken and can't be used so build scripts have been updated to download the zip instance available instead